### PR TITLE
fix env

### DIFF
--- a/src/components/Hero/Heros.jsx
+++ b/src/components/Hero/Heros.jsx
@@ -31,7 +31,7 @@ const Heros = () => {
         tierPokemon,
     } = useHeroContext();
 
-    if (process.env.NODE_ENV === "production") {
+    if (import.meta.env.NODE_ENV === "production") {
         console.log("production");
     }
     //fetch pokemon data

--- a/src/components/Hero/useHeroContext.jsx
+++ b/src/components/Hero/useHeroContext.jsx
@@ -94,7 +94,7 @@ export const HeroProvider = ({ children }) => {
                 //移除目前已存在的pokemon
                 return newSelectImg.filter((img) => img.enName !== item.enName);
             } else {
-                if (process.env.NODE_ENV === "deploy") {
+                if (import.meta.env.NODE_ENV === "deploy") {
                     //POST點擊次數
                     // postFirebase(item);
                 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -19,7 +19,7 @@ import About from "./routes/About";
 import TypeView from "./components/Hero/TypeView";
 import ComingSoon from "./routes/ComingSoon";
 
-const defaultPath = process.env.VITE_BASE_PATH || "/Pokemon-Gym";
+const defaultPath = import.meta.env.VITE_BASE_PATH || "/Pokemon-Gym";
 
 const router = createBrowserRouter([
     {
@@ -41,7 +41,7 @@ const router = createBrowserRouter([
                         children: [
                             {
                                 path:
-                                    process.env.VITE_BASE_PATH || "type/:type",
+                                    import.meta.env.VITE_BASE_PATH || "type/:type",
                                 element: <TypeView />,
                             },
                         ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,5 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    base: process.env.VITE_BASE_PATH || "/pokemon-Gym/",
     plugins: [react()],
 });


### PR DESCRIPTION
在用 vite 寫 SPA 的時候盡量都用 [`import.meta.env`](https://vitejs.dev/guide/env-and-mode#env-files) 來取的 env，不然在前端 (瀏覽器) 是拿不到 `process` 這個變數的，這是 nodejs 才有的 global 變數。

目前我們還沒有太多什麼是跑在前端，什麼是跑在後端的經驗，我先不多做著墨，但簡單來說:

- vite.config.js 跟 index.html 會跑在 server
- 其他都會被 compile 之後跑在前端
  - 也就是說，你這行 https://github.com/DoubleTian-tw/pokemon-Gym/blob/c00dbbfd60e17b57c9ae10c76c632d8709343700/src/main.jsx#L22 會跑在前端，造成 `process` 會是 `undefined`
![image](https://github.com/DoubleTian-tw/pokemon-Gym/assets/38932402/93c04da6-4313-4250-a20f-6d5690383449)
